### PR TITLE
Feat: 성인인증 guard, strategy 구현

### DIFF
--- a/src/domain/authentication/authentication.controller.ts
+++ b/src/domain/authentication/authentication.controller.ts
@@ -43,25 +43,53 @@ export class AuthenticationController {
   @HttpCode(200)
   @Post('/login/kakao')
   @ApiOperation({ summary: '카카오 로그인' })
-  async kakaoLogin(@Body() authorizationCode: string) {
-    return await this.authenticationService.kakaoLogin(authorizationCode);
+  async kakaoLogin(
+    @Body() authorizationCode: string,
+    @Res() response: Response,
+  ) {
+    const { user, accessCookie, refreshCookie } =
+      await this.authenticationService.socialLogin(
+        'kakao',
+        authorizationCode,
+        null,
+      );
+    response.setHeader('Set-Cookie', [accessCookie, refreshCookie]);
+    return response.send(user);
   }
 
   @HttpCode(200)
   @Post('/login/naver')
   @ApiOperation({ summary: '네이버 로그인' })
-  async naverLogin(@Body() authorizationCode: string, state: string) {
-    return await this.authenticationService.naverLogin(
-      authorizationCode,
-      state,
-    );
+  async naverLogin(
+    @Body() authorizationCode: string,
+    state: string,
+    @Res() response: Response,
+  ) {
+    const { user, accessCookie, refreshCookie } =
+      await this.authenticationService.socialLogin(
+        'naver',
+        authorizationCode,
+        state,
+      );
+    response.setHeader('Set-Cookie', [accessCookie, refreshCookie]);
+    return response.send(user);
   }
 
   @HttpCode(200)
   @Post('/login/google')
   @ApiOperation({ summary: '구글 로그인' })
-  async googleLogin(@Body() authorizationCode: string) {
-    return await this.authenticationService.googleLogin(authorizationCode);
+  async googleLogin(
+    @Body() authorizationCode: string,
+    @Res() response: Response,
+  ) {
+    const { user, accessCookie, refreshCookie } =
+      await this.authenticationService.socialLogin(
+        'google',
+        authorizationCode,
+        null,
+      );
+    response.setHeader('Set-Cookie', [accessCookie, refreshCookie]);
+    return response.send(user);
   }
 
   @UseGuards(JwtAuthenticationGuard)

--- a/src/domain/authentication/guards/adult-authentication.guard.ts
+++ b/src/domain/authentication/guards/adult-authentication.guard.ts
@@ -2,4 +2,4 @@ import { Injectable } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
 @Injectable()
-export class AdultAuthenticationGuard extends AuthGuard('jwt') {}
+export class AdultAuthenticationGuard extends AuthGuard('adult') {}

--- a/src/domain/authentication/guards/adult-authentication.guard.ts
+++ b/src/domain/authentication/guards/adult-authentication.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class AdultAuthenticationGuard extends AuthGuard('jwt') {}

--- a/src/domain/authentication/passport/adult.strategy.ts
+++ b/src/domain/authentication/passport/adult.strategy.ts
@@ -1,0 +1,43 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ConfigService } from '@nestjs/config';
+import { UsersService } from '@/domain/users/users.service';
+import { Request } from 'express';
+import { Strategy } from 'passport-local';
+import { ExtractJwt } from 'passport-jwt';
+import TokenPayload from '../interfaces/token-payload.interface';
+
+@Injectable()
+export class AdultStrategy extends PassportStrategy(Strategy) {
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly userService: UsersService,
+  ) {
+    super({
+      jwtFromRequest: ExtractJwt.fromExtractors([
+        (request: Request) => {
+          return request?.cookies?.accessToken;
+        },
+        (request: Request) => {
+          return request?.cookies?.refreshToken;
+        },
+      ]),
+      secretOrKey: configService.get('JWT_SECRET'),
+      passReqToCallback: true,
+    });
+  }
+
+  async validate(payload: TokenPayload): Promise<void> {
+    const user = await this.userService.findById(payload.userId);
+
+    if (user.isVerified) {
+      if (new Date(user.credential.birthYear).getFullYear() <= 1999) {
+        return;
+      } else {
+        throw new UnauthorizedException('성인 인증에 실패했습니다.');
+      }
+    } else {
+      throw new UnauthorizedException('본인 인증이 필요합니다.');
+    }
+  }
+}

--- a/src/domain/authentication/passport/jwt.strategy.ts
+++ b/src/domain/authentication/passport/jwt.strategy.ts
@@ -12,7 +12,7 @@ import TokenPayload from '../interfaces/token-payload.interface';
 export class JwtStrategy extends PassportStrategy(Strategy) {
   constructor(
     private readonly configService: ConfigService,
-    private readonly userService: UsersService,
+    private readonly usersService: UsersService,
     private readonly authenticationService: AuthenticationService,
   ) {
     super({
@@ -36,14 +36,14 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       );
     }
     // 액세스 토큰 검증
-    const foundUser = await this.userService.findById(payload.userId);
+    const foundUser = await this.usersService.findById(payload.userId);
     if (!foundUser) {
       // 액세스 토큰이 만료된 경우 리프레시 토큰 검증(유효하다면 액세스 토큰 재발급)
       const refreshToken = req.cookies.refreshToken as string;
       if (!refreshToken) {
         throw new UnauthorizedException('인증되지 않은 사용자입니다.');
       }
-      const refreshUser = await this.userService.findById(payload.userId);
+      const refreshUser = await this.usersService.findById(payload.userId);
       if (!refreshUser) {
         throw new UnauthorizedException('새로 로그인해야 합니다.');
       }


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) #이슈번호, #이슈번호
#2 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 소셜로그인 코드 리팩토링
- 성인 인증 guard, strategy 구현(성인인증이 필요한 요청 시 → 만약 isVerified: true면 출생년도 확인, 연령제한로직 통과하면 19카테고리 접속, 통과하지 않으면 성인인증 실패 / isVerified: false면 본인인증 필요)

> 성인 게시글 리스트, 게시글 상세 요청 시 아래와 같이 사용할 수 있습니다.
- @UseGuards() 데코레이터에 전달된 Guard는 왼쪽에서 오른쪽으로 순서대로 실행됩니다.
- JWT 인증이 성공하면, 그 다음 성인 인증이 수행될 수 있도록 하면 됩니다. JWT 인증에 실패하면 성인 인증은 수행되지 않습니다.
```ts
import { Controller, Get, UseGuards } from '@nestjs/common';
import { AdultAuthenticationGuard } from './adult-authentication.guard';
import { JwtAuthenticationGuard } from './jwt-authentication.guard';

@Controller('posts')
export class PostsController {
  @Get()
  @UseGuards(JwtAuthenticationGuard, AdultAuthenticationGuard)
  async getPosts() {}
}
```

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
