### PR TITLE
Feat: Item 관련 구체적으로 필요한 기능들 추가(포인트샵, 관리자 페이지) #11

### DIFF
--- a/src/domain/authentication/authentication.controller.ts
+++ b/src/domain/authentication/authentication.controller.ts
@@ -10,7 +10,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { AuthenticationService } from './authentication.service';
-import { ApiOperation } from '@nestjs/swagger';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { CreateUserDto } from '../users/dto/create-user.dto';
 import RequestWithUser from './interfaces/request-with-user.interface';
 import { Response } from 'express';
@@ -18,6 +18,7 @@ import { JwtAuthenticationGuard } from './guards/jwt-authentication.guard';
 import { RefreshAuthenticationGuard } from './guards/refresh-authentication.guard';
 
 @Controller('authentication')
+@ApiTags('authentication')
 export class AuthenticationController {
   constructor(private readonly authenticationService: AuthenticationService) {}
 
@@ -108,8 +109,8 @@ export class AuthenticationController {
   }
 
   @HttpCode(200)
-  @UseGuards(JwtAuthenticationGuard)
   @Post('/logout')
+  @UseGuards(JwtAuthenticationGuard)
   @ApiOperation({ summary: '로그아웃' })
   async logout(@Res() response: Response) {
     const { accessCookie, refreshCookie } =

--- a/src/domain/items/dto/create-item.dto.ts
+++ b/src/domain/items/dto/create-item.dto.ts
@@ -35,4 +35,12 @@ export class CreateItemDto {
   })
   @IsNumber()
   readonly price: number;
+
+  @ApiProperty({
+    example: 'https://example.com/image.jpg',
+    description: '이미지 url',
+    required: true,
+  })
+  @IsString()
+  readonly image: string;
 }

--- a/src/domain/items/entities/item-cart.entity.ts
+++ b/src/domain/items/entities/item-cart.entity.ts
@@ -1,0 +1,24 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  OneToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { User } from '@/domain/users/entities/user.entity';
+
+@Entity({ name: 'item_cart' })
+export class ItemCart {
+  @PrimaryGeneratedColumn('increment')
+  id: number;
+
+  @OneToOne('User', 'itemCart', { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  @Column({ type: 'simple-array', nullable: true })
+  items: number[];
+
+  @Column({ name: 'total_points', type: 'int', default: 0 })
+  totalPoints: number;
+}

--- a/src/domain/items/entities/item.entity.ts
+++ b/src/domain/items/entities/item.entity.ts
@@ -26,6 +26,9 @@ export class Item {
   @Column()
   price: number;
 
+  @Column()
+  image: string;
+
   @Column({ name: 'purchased_count', type: 'int', default: 0 })
   purchasedCount: number;
 

--- a/src/domain/items/items.controller.ts
+++ b/src/domain/items/items.controller.ts
@@ -6,36 +6,130 @@ import {
   Patch,
   Param,
   Delete,
+  Query,
+  Req,
+  UseGuards,
+  HttpCode,
 } from '@nestjs/common';
 import { ItemsService } from './items.service';
 import { CreateItemDto } from './dto/create-item.dto';
 import { UpdateItemDto } from './dto/update-item.dto';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ItemType } from '@/@types/enum/item-type.enum';
+import RequestWithUser from '../authentication/interfaces/request-with-user.interface';
+import { JwtAuthenticationGuard } from '../authentication/guards/jwt-authentication.guard';
 
 @Controller('items')
+@ApiTags('items')
 export class ItemsController {
   constructor(private readonly itemsService: ItemsService) {}
 
+  /* 포인트샵 페이지 */
+  @Get('/cat')
+  @ApiOperation({ summary: '고양이 아이템 조회' })
+  async findCatItems(@Query('itemType') itemType: ItemType) {
+    return await this.itemsService.findCatItems(itemType);
+  }
+
+  @Get('/dog')
+  @ApiOperation({ summary: '개 아이템 조회' })
+  async findDogItems(@Query('itemType') itemType: ItemType) {
+    return await this.itemsService.findDogItems(itemType);
+  }
+
+  @Get('/fox')
+  @ApiOperation({ summary: '여우 아이템 조회' })
+  async findFoxItems(@Query('itemType') itemType: ItemType) {
+    return await this.itemsService.findFoxItems(itemType);
+  }
+
+  @Get('/bear')
+  @ApiOperation({ summary: '곰 아이템 조회' })
+  async findBearItems(@Query('itemType') itemType: ItemType) {
+    return await this.itemsService.findBearItems(itemType);
+  }
+
+  @HttpCode(200)
+  @Post(':id')
+  @UseGuards(JwtAuthenticationGuard)
+  @ApiOperation({ summary: '장바구니에 아이템 추가' })
+  async addToCart(@Param('id') id: string, @Req() req: RequestWithUser) {
+    await this.itemsService.addToCart(+id, req.user);
+    return { message: '장바구니에 아이템이 추가되었습니다.' };
+  }
+
+  @Get()
+  @UseGuards(JwtAuthenticationGuard)
+  @ApiOperation({ summary: '장바구니 조회' })
+  async getCartItems(@Req() req: RequestWithUser) {
+    return await this.itemsService.getCartItems(req.user);
+  }
+
+  @Patch()
+  @UseGuards(JwtAuthenticationGuard)
+  @ApiOperation({ summary: '장바구니 전체 아이템 구매' })
+  async purchaseAllCartItems(@Req() req: RequestWithUser) {
+    const remainingPoints = await this.itemsService.purchaseAllCartItems(
+      req.user,
+    );
+    return {
+      message: '아이템 구매가 완료되었습니다.',
+      points: remainingPoints,
+    };
+  }
+
+  @Delete(':id')
+  @UseGuards(JwtAuthenticationGuard)
+  @ApiOperation({ summary: '장바구니 아이템 취소' })
+  async removeFromCart(@Param('id') id: string, @Req() req: RequestWithUser) {
+    await this.itemsService.removeFromCart(+id, req.user);
+    return { message: '장바구니에서 선택한 아이템이 삭제되었습니다.' };
+  }
+
+  @Delete()
+  @UseGuards(JwtAuthenticationGuard)
+  @ApiOperation({ summary: '장바구니 전체 아이템 취소' })
+  async removeAllFromCart(@Req() req: RequestWithUser) {
+    await this.itemsService.removeAllFromCart(req.user);
+    return { message: '장바구니의 전체 아이템이 삭제되었습니다.' };
+  }
+
+  // TODO: 아이템 조회 페이지네이션 적용 전
+  // TODO: 스웨거 작성
+
+  /* 마이페이지 */
+  // TODO: 유저가 가진 아이템 조회 → *user*.items 조회할 때 아이템 최신순으로
+  // TODO: 아이템 착용 → 만약 아이템 동물과 유저 동물이 같지 않다면 오류, 아이템 타입이 같은 건 덮어씌우기
+  // TODO: 아이템 착용 취소
+  // TODO: 아이템 판매 → +포인트
+
+  /* 관리자 페이지 */
   @Post()
+  @ApiOperation({ summary: '아이템 생성' })
   async create(@Body() createItemDto: CreateItemDto) {
     return await this.itemsService.create(createItemDto);
   }
 
-  @Get()
+  @Get('/admins')
+  @ApiOperation({ summary: '전체 아이템 조회' })
   async findAll() {
     return await this.itemsService.findAll();
   }
 
-  @Get(':id')
+  @Get('/admins/:id')
+  @ApiOperation({ summary: '아이템 상세 조회' })
   async findOne(@Param('id') id: string) {
     return await this.itemsService.findOne(+id);
   }
 
-  @Patch(':id')
+  @Patch('/admins/:id')
+  @ApiOperation({ summary: '아이템 수정' })
   async update(@Param('id') id: string, @Body() updateItemDto: UpdateItemDto) {
     return await this.itemsService.update(+id, updateItemDto);
   }
 
-  @Delete(':id')
+  @Delete('/admins/:id')
+  @ApiOperation({ summary: '아이템 삭제' })
   async remove(@Param('id') id: string) {
     await this.itemsService.remove(+id);
     return { message: 'Item has been soft deleted successfully' };

--- a/src/domain/items/items.controller.ts
+++ b/src/domain/items/items.controller.ts
@@ -18,6 +18,7 @@ import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { ItemType } from '@/@types/enum/item-type.enum';
 import RequestWithUser from '../authentication/interfaces/request-with-user.interface';
 import { JwtAuthenticationGuard } from '../authentication/guards/jwt-authentication.guard';
+import { Animal } from '@/@types/enum/animal.enum';
 
 @Controller('items')
 @ApiTags('items')
@@ -25,32 +26,17 @@ export class ItemsController {
   constructor(private readonly itemsService: ItemsService) {}
 
   /* 포인트샵 페이지 */
-  @Get('/cat')
-  @ApiOperation({ summary: '고양이 아이템 조회' })
-  async findCatItems(@Query('itemType') itemType: ItemType) {
-    return await this.itemsService.findCatItems(itemType);
-  }
-
-  @Get('/dog')
-  @ApiOperation({ summary: '개 아이템 조회' })
-  async findDogItems(@Query('itemType') itemType: ItemType) {
-    return await this.itemsService.findDogItems(itemType);
-  }
-
-  @Get('/fox')
-  @ApiOperation({ summary: '여우 아이템 조회' })
-  async findFoxItems(@Query('itemType') itemType: ItemType) {
-    return await this.itemsService.findFoxItems(itemType);
-  }
-
-  @Get('/bear')
-  @ApiOperation({ summary: '곰 아이템 조회' })
-  async findBearItems(@Query('itemType') itemType: ItemType) {
-    return await this.itemsService.findBearItems(itemType);
+  @Get()
+  @ApiOperation({ summary: '동물별 아이템 조회' })
+  async findItemsByAnimalAndType(
+    @Query('animal') animal: Animal,
+    @Query('itemType') itemType: ItemType,
+  ) {
+    return await this.itemsService.findItemsByAnimalAndType(animal, itemType);
   }
 
   @HttpCode(200)
-  @Post(':id')
+  @Post('/cart/:id')
   @UseGuards(JwtAuthenticationGuard)
   @ApiOperation({ summary: '장바구니에 아이템 추가' })
   async addToCart(@Param('id') id: string, @Req() req: RequestWithUser) {
@@ -58,14 +44,14 @@ export class ItemsController {
     return { message: '장바구니에 아이템이 추가되었습니다.' };
   }
 
-  @Get()
+  @Get('/cart')
   @UseGuards(JwtAuthenticationGuard)
   @ApiOperation({ summary: '장바구니 조회' })
   async getCartItems(@Req() req: RequestWithUser) {
     return await this.itemsService.getCartItems(req.user);
   }
 
-  @Patch()
+  @Patch('/cart')
   @UseGuards(JwtAuthenticationGuard)
   @ApiOperation({ summary: '장바구니 전체 아이템 구매' })
   async purchaseAllCartItems(@Req() req: RequestWithUser) {
@@ -78,7 +64,7 @@ export class ItemsController {
     };
   }
 
-  @Delete(':id')
+  @Delete('/cart/:id')
   @UseGuards(JwtAuthenticationGuard)
   @ApiOperation({ summary: '장바구니 아이템 취소' })
   async removeFromCart(@Param('id') id: string, @Req() req: RequestWithUser) {
@@ -86,7 +72,7 @@ export class ItemsController {
     return { message: '장바구니에서 선택한 아이템이 삭제되었습니다.' };
   }
 
-  @Delete()
+  @Delete('/cart')
   @UseGuards(JwtAuthenticationGuard)
   @ApiOperation({ summary: '장바구니 전체 아이템 취소' })
   async removeAllFromCart(@Req() req: RequestWithUser) {

--- a/src/domain/items/items.module.ts
+++ b/src/domain/items/items.module.ts
@@ -3,9 +3,11 @@ import { ItemsService } from './items.service';
 import { ItemsController } from './items.controller';
 import { Item } from './entities/item.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ItemCart } from './entities/item-cart.entity';
+import { User } from '../users/entities/user.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Item])],
+  imports: [TypeOrmModule.forFeature([Item, ItemCart, User])],
   controllers: [ItemsController],
   providers: [ItemsService],
 })

--- a/src/domain/items/items.service.ts
+++ b/src/domain/items/items.service.ts
@@ -26,34 +26,13 @@ export class ItemsService {
 
   /* 포인트샵 페이지 */
 
-  // 고양이 아이템 조회
-  async findCatItems(itemType: ItemType): Promise<Item[]> {
+  // 동물별 아이템 조회
+  async findItemsByAnimalAndType(
+    animal: Animal,
+    itemType: ItemType,
+  ): Promise<Item[]> {
     return await this.itemRepository.find({
-      where: { animal: Animal.CAT, itemType },
-      order: { createdAt: 'DESC' },
-    });
-  }
-
-  // 개 아이템 조회
-  async findDogItems(itemType: ItemType): Promise<Item[]> {
-    return await this.itemRepository.find({
-      where: { animal: Animal.DOG, itemType },
-      order: { createdAt: 'DESC' },
-    });
-  }
-
-  // 여우 아이템 조회
-  async findFoxItems(itemType: ItemType): Promise<Item[]> {
-    return await this.itemRepository.find({
-      where: { animal: Animal.FOX, itemType },
-      order: { createdAt: 'DESC' },
-    });
-  }
-
-  // 곰 아이템 조회
-  async findBearItems(itemType: ItemType): Promise<Item[]> {
-    return await this.itemRepository.find({
-      where: { animal: Animal.BEAR, itemType },
+      where: { animal, itemType },
       order: { createdAt: 'DESC' },
     });
   }

--- a/src/domain/items/items.service.ts
+++ b/src/domain/items/items.service.ts
@@ -1,46 +1,220 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { CreateItemDto } from './dto/create-item.dto';
 import { UpdateItemDto } from './dto/update-item.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Item } from './entities/item.entity';
+import { ItemType } from '@/@types/enum/item-type.enum';
+import { Animal } from '@/@types/enum/animal.enum';
+import { User } from '../users/entities/user.entity';
+import { ItemCart } from './entities/item-cart.entity';
+import {
+  ItemBadRequestException,
+  ItemNotFoundException,
+} from '@/lib/exceptions/domain/items.exception';
 
 @Injectable()
 export class ItemsService {
   constructor(
     @InjectRepository(Item)
     private readonly itemRepository: Repository<Item>,
+    @InjectRepository(ItemCart)
+    private readonly itemCartRepository: Repository<ItemCart>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
   ) {}
 
+  /* 포인트샵 페이지 */
+
+  // 고양이 아이템 조회
+  async findCatItems(itemType: ItemType): Promise<Item[]> {
+    return await this.itemRepository.find({
+      where: { animal: Animal.CAT, itemType },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  // 개 아이템 조회
+  async findDogItems(itemType: ItemType): Promise<Item[]> {
+    return await this.itemRepository.find({
+      where: { animal: Animal.DOG, itemType },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  // 여우 아이템 조회
+  async findFoxItems(itemType: ItemType): Promise<Item[]> {
+    return await this.itemRepository.find({
+      where: { animal: Animal.FOX, itemType },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  // 곰 아이템 조회
+  async findBearItems(itemType: ItemType): Promise<Item[]> {
+    return await this.itemRepository.find({
+      where: { animal: Animal.BEAR, itemType },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  // 장바구니에 아이템 추가
+  async addToCart(id: number, user: User): Promise<void> {
+    const item = await this.findOne(id);
+    const itemCart = await this.itemCartRepository
+      .createQueryBuilder('item_cart')
+      .leftJoinAndSelect('item_cart.user', 'user')
+      .where('user.id = :userId', { userId: user.id })
+      .getOne();
+    if (!itemCart) {
+      throw new ItemNotFoundException(`Cart not found for user ${user.id}`);
+    }
+
+    if (!itemCart.items) {
+      itemCart.items = [];
+    } else if (itemCart.items.find((itemId) => Number(itemId) === item.id)) {
+      throw new ItemBadRequestException(
+        '장바구니에 이미 같은 아이템이 있습니다.',
+      );
+    }
+
+    itemCart.items.unshift(item.id);
+    itemCart.totalPoints += item.price; // 총 포인트에 해당 아이템 가격 더하기
+    await this.itemCartRepository.save(itemCart);
+  }
+
+  // 장바구니 조회
+  async getCartItems(
+    user: User,
+  ): Promise<{ items: Item[]; totalPoints: number }> {
+    const itemCart = await this.itemCartRepository
+      .createQueryBuilder('item_cart')
+      .leftJoinAndSelect('item_cart.user', 'user')
+      .where('user.id = :userId', { userId: user.id })
+      .getOne();
+    if (!itemCart || !itemCart.items) {
+      return { items: [], totalPoints: 0 };
+    }
+
+    const items = await this.itemRepository
+      .createQueryBuilder('item')
+      .whereInIds(itemCart.items)
+      .getMany();
+
+    const sortedItems = itemCart.items.map((itemId) =>
+      items.find((item) => item.id === Number(itemId)),
+    );
+
+    return { items: sortedItems, totalPoints: itemCart.totalPoints };
+  }
+
+  // 장바구니 전체 아이템 구매
+  async purchaseAllCartItems(user: User): Promise<number> {
+    const itemCart = await this.itemCartRepository
+      .createQueryBuilder('item_cart')
+      .leftJoinAndSelect('item_cart.user', 'user')
+      .where('user.id = :userId', { userId: user.id })
+      .getOne();
+    if (!itemCart) {
+      throw new ItemNotFoundException(`Cart not found for user ${user.id}`);
+    } else if (!itemCart.items) {
+      throw new ItemBadRequestException('선택한 아이템이 없습니다.');
+    }
+
+    const itemsArray = await this.itemRepository
+      .createQueryBuilder('item')
+      .whereInIds(itemCart.items)
+      .getMany();
+
+    if (user.points < itemCart.totalPoints) {
+      throw new ItemBadRequestException('포인트가 부족합니다.');
+    }
+    user.points -= itemCart.totalPoints; // 유저 포인트에서 차감
+    if (!user.items) {
+      user.items = itemCart.items;
+    } else {
+      user.items.push(...itemCart.items); // user.items에 추가
+    }
+    await this.userRepository.save(user);
+
+    for (const item of itemsArray) {
+      item.purchasedCount += 1; // 아이템 구매 수량 +1
+      await this.itemRepository.save(item);
+    }
+
+    itemCart.items = [];
+    itemCart.totalPoints = 0;
+    await this.itemCartRepository.save(itemCart);
+
+    return user.points;
+  }
+
+  // 장바구니 아이템 취소
+  async removeFromCart(id: number, user: User): Promise<void> {
+    const item = await this.findOne(id);
+    const itemCart = await this.itemCartRepository
+      .createQueryBuilder('item_cart')
+      .leftJoinAndSelect('item_cart.user', 'user')
+      .where('user.id = :userId', { userId: user.id })
+      .getOne();
+    if (!itemCart) {
+      throw new ItemNotFoundException(`Cart not found for user ${user.id}`);
+    }
+
+    itemCart.items = itemCart.items.filter((itemId) => Number(itemId) !== id);
+    itemCart.totalPoints -= item.price; // 총 포인트에 해당 아이템 가격 빼기
+    await this.itemCartRepository.save(itemCart);
+  }
+
+  // 장바구니 전체 아이템 취소
+  async removeAllFromCart(user: User): Promise<void> {
+    const itemCart = await this.itemCartRepository
+      .createQueryBuilder('item_cart')
+      .leftJoinAndSelect('item_cart.user', 'user')
+      .where('user.id = :userId', { userId: user.id })
+      .getOne();
+    if (!itemCart) {
+      throw new ItemNotFoundException(`Cart not found for user ${user.id}`);
+    }
+
+    itemCart.items = [];
+    itemCart.totalPoints = 0;
+    await this.itemCartRepository.save(itemCart);
+  }
+
+  /* 관리자 페이지 */
+
+  // 아이템 생성
   async create(createItemDto: CreateItemDto): Promise<Item> {
     const newItem = this.itemRepository.create(createItemDto);
     return await this.itemRepository.save(newItem);
   }
 
+  // 전체 아이템 조회
   async findAll(): Promise<Item[]> {
     return await this.itemRepository.find();
   }
 
+  // 아이템 상세 조회
   async findOne(id: number): Promise<Item> {
-    return await this.itemRepository.findOneBy({ id });
+    const item = await this.itemRepository.findOneBy({ id });
+    if (!item) {
+      throw new ItemNotFoundException(`Item with id ${id} not found`);
+    }
+
+    return item;
   }
 
+  // 아이템 수정
   async update(id: number, updateItemDto: UpdateItemDto): Promise<Item> {
     const itemToUpdate = await this.findOne(id);
-    if (!itemToUpdate) {
-      throw new NotFoundException(`Item with id ${id} not found`);
-    }
     const updatedItem = Object.assign(itemToUpdate, updateItemDto);
     return await this.itemRepository.save(updatedItem);
   }
 
+  // 아이템 삭제
   async remove(id: number): Promise<void> {
-    const itemToRemove = await this.itemRepository.findOne({
-      where: { id, deletedAt: undefined },
-    });
-    if (!itemToRemove) {
-      throw new NotFoundException(`Item with id ${id} not found`);
-    }
+    await this.findOne(id);
     await this.itemRepository.softDelete(id);
   }
 }

--- a/src/domain/users/entities/exit-reason.entity.ts
+++ b/src/domain/users/entities/exit-reason.entity.ts
@@ -6,12 +6,12 @@ export class ExitReason {
   @PrimaryGeneratedColumn('increment')
   id: number;
 
-  @Column()
+  @Column({ name: 'user_id' })
   userId: string;
 
   @Column({ type: 'enum', enum: ExitReasonEnum })
   reason: ExitReasonEnum;
 
-  @Column({ type: 'text', nullable: true })
+  @Column({ name: 'other_reasons', type: 'text', nullable: true })
   otherReasons: string; // Only applicable if reason is 'OTHER'
 }

--- a/src/domain/users/entities/user.entity.ts
+++ b/src/domain/users/entities/user.entity.ts
@@ -13,6 +13,8 @@ import { AuthenticationProvider, State } from '@/@types/enum/user.enum';
 import { Animal } from '@/@types/enum/animal.enum';
 import { Credential } from './credential.entity';
 import { Post } from '@/domain/posts/entities/post.entity';
+import { ItemCart } from '@/domain/items/entities/item-cart.entity';
+import { Item } from '@/domain/items/entities/item.entity';
 
 @Entity({ name: 'users' })
 export class User {
@@ -64,8 +66,14 @@ export class User {
   // @OneToMany(() => Message, (message) => message.user)
   // messages: Message[];
 
-  // @OneToMany(() => Item, (item) => item.user)
-  // items: Item[];
+  @Column({ type: 'simple-array', nullable: true })
+  profileItems: Item[] | number[]; // 착용한 아이템
+
+  @Column({ type: 'simple-array', nullable: true })
+  items: number[]; // 갖고 있는 아이템
+
+  @OneToOne('ItemCart', 'user', { cascade: true })
+  itemCart: ItemCart;
 
   // @OneToMany(() => Sticker, (stickers) => stickers.user)
   // givenStickers: Sticker[];

--- a/src/domain/users/users.module.ts
+++ b/src/domain/users/users.module.ts
@@ -10,10 +10,19 @@ import { RedisCacheService } from '../redis-cache/redis-cache.service';
 import { HttpModule } from '@nestjs/axios';
 import { JwtAuthenticationGuard } from '../authentication/guards/jwt-authentication.guard';
 import { JwtService } from '@nestjs/jwt';
+import { ItemCart } from '../items/entities/item-cart.entity';
+import { Item } from '../items/entities/item.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([User, Credential, UserAuthority, ExitReason]),
+    TypeOrmModule.forFeature([
+      User,
+      Credential,
+      UserAuthority,
+      ExitReason,
+      ItemCart,
+      Item,
+    ]),
     HttpModule,
   ],
   controllers: [UsersController],

--- a/src/lib/exceptions/domain/items.exception.ts
+++ b/src/lib/exceptions/domain/items.exception.ts
@@ -1,0 +1,15 @@
+import { BaseException } from '@/lib/exceptions/base.exception';
+import { HttpStatus } from '@nestjs/common';
+import { ItemExceptionEnum } from '../exception.enum';
+
+export class ItemNotFoundException extends BaseException {
+  constructor(message: string) {
+    super(ItemExceptionEnum.ITEM_NOT_FOUND, HttpStatus.NOT_FOUND, message);
+  }
+}
+
+export class ItemBadRequestException extends BaseException {
+  constructor(message: string) {
+    super(ItemExceptionEnum.ITEM_BAD_REQUEST, HttpStatus.BAD_REQUEST, message);
+  }
+}

--- a/src/lib/exceptions/exception.enum.ts
+++ b/src/lib/exceptions/exception.enum.ts
@@ -56,8 +56,13 @@ export enum AuthExceptionEnum {
 }
 
 export enum UserExceptionEnum {
-  USER_NOT_FOUND = '5001',
   USER_BAD_REQUEST = '5000',
+  USER_NOT_FOUND = '5001',
+}
+
+export enum ItemExceptionEnum {
+  ITEM_BAD_REQUEST = '6000',
+  ITEM_NOT_FOUND = '6001',
 }
 
 export enum LikeExceptionEnum {


### PR DESCRIPTION
## #️⃣연관된 이슈
#11

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- item_cart entity 추가
- 포인트샵에서 필요한 기능들 구현(각 동물・타입별 아이템 조회, 장바구니에 아이템 추가, 조회, 삭제, 구매 등)
- user entity에 profileItems(착용한 아이템), items(구입한 아이템), itemCart 추가
- user -> findById 조회 시 profileItems의 내용도 같이 보이도록 수정
- TODO: 스웨거 작성 예정
- TODO: 마이페이지에서 유저 아이템 조회, 착용, 착용 취소, 판매 등 기능들 구현 예정
- TODO: 아이템 조회 페이지네이션 적용 전 -> 상의 후 적용 예정

장바구니 조회를 작성하면서 QueryBuilder로 아이템의 id를 조회할 때, 배열의 순서가 id의 숫자 순서대로 정렬돼서 반환되는 문제가 있었습니다.
그래서 기존의 배열 순서대로 다시 정렬하는 작업을 해서 해결했습니다!
관련해서 더 좋은 해결방법 아시면 말씀해주세요!
```ts
  // 장바구니 조회
  async getCartItems(
    user: User,
  ): Promise<{ items: Item[]; totalPoints: number }> {
    const itemCart = await this.itemCartRepository
      .createQueryBuilder('item_cart')
      .leftJoinAndSelect('item_cart.user', 'user')
      .where('user.id = :userId', { userId: user.id })
      .getOne();
    if (!itemCart || !itemCart.items) {
      return { items: [], totalPoints: 0 };
    }

    const items = await this.itemRepository
      .createQueryBuilder('item')
      .whereInIds(itemCart.items)
      .getMany();

    const sortedItems = itemCart.items.map((itemId) =>
      items.find((item) => item.id === Number(itemId)),
    );

    return { items: sortedItems, totalPoints: itemCart.totalPoints };
  }
```
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
