### PR TITLE
Feat: 검색 기록 중복 저장 x, 한번 더 검색하면 최신 기록으로 전환, 조회 API 페이지네이션 적용

### DIFF
--- a/src/domain/search-histories/entities/search-history.entity.ts
+++ b/src/domain/search-histories/entities/search-history.entity.ts
@@ -2,7 +2,9 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  Index,
   PrimaryGeneratedColumn,
+  UpdateDateColumn,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 
@@ -19,13 +21,14 @@ export class SearchHistory {
     description: '검색 키워드',
     type: String,
   })
-  @Column({ nullable: false })
+  @Column({ nullable: false, unique: true })
   keyword: string;
 
   @ApiProperty({
     description: '유저 아이디',
     type: String,
   })
+  @Index()
   @Column({ name: 'user_id', nullable: false })
   userId: string;
 
@@ -35,4 +38,12 @@ export class SearchHistory {
   })
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
+
+  @ApiProperty({
+    description: '검색 최신일자',
+    type: Date,
+  })
+  @Index()
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#87 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 검색 기록 중복 저장 제거
- 같은 검색어를 한번 더 검색하면 최신 기록으로 전환
- 조회 API에 페이지네이션 적용

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
