### PR TITLE
messageRoom 쿼리빌더 리팩토링, getRooms lastMessage에 createdAt 추가

### DIFF
--- a/src/domain/messages/dto/message-response.dto.ts
+++ b/src/domain/messages/dto/message-response.dto.ts
@@ -1,7 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Expose } from 'class-transformer';
 import { MessageRoom } from '../entities/message-room.entity';
-import { UserProfileDto } from '@/domain/users/dto/user-profile.dto';
 import { Message } from '../entities/message.entity';
 
 export class MessageResponseDto {
@@ -13,13 +12,13 @@ export class MessageResponseDto {
   @Expose()
   readonly messageRoom: MessageRoom;
 
-  @ApiProperty({ type: UserProfileDto, description: '발신자' })
+  @ApiProperty({ type: String, description: '발신자' })
   @Expose()
-  readonly sender: UserProfileDto;
+  readonly sender: string;
 
-  @ApiProperty({ type: UserProfileDto, description: '수신자' })
+  @ApiProperty({ type: String, description: '수신자' })
   @Expose()
-  readonly receiver: UserProfileDto;
+  readonly receiver: string;
 
   @ApiProperty({ type: String, description: '메세지 내용' })
   @Expose()
@@ -36,8 +35,8 @@ export class MessageResponseDto {
   constructor(message: Message) {
     this.id = message.id;
     this.messageRoom = message.messageRoom;
-    this.sender = new UserProfileDto(message.sender);
-    this.receiver = new UserProfileDto(message.receiver);
+    this.sender = message.sender.id;
+    this.receiver = message.receiver.id;
     this.content = message.content;
     this.isRead = message.isRead;
     this.createdAt = message.createdAt;

--- a/src/domain/messages/messages.controller.ts
+++ b/src/domain/messages/messages.controller.ts
@@ -338,7 +338,16 @@ export class MessagesController {
                   },
                 },
               },
-              lastMessage: { type: 'string', example: '안녕하세요' },
+              lastMessage: {
+                type: 'object',
+                properties: {
+                  content: { type: 'string', example: '안녕하세요' },
+                  createdAt: {
+                    type: 'string',
+                    example: '2024-02-23T16:18:23.621Z',
+                  },
+                },
+              },
               unreadMessageCount: { type: 'number', example: 2 },
             },
           },

--- a/src/domain/messages/messages.controller.ts
+++ b/src/domain/messages/messages.controller.ts
@@ -327,8 +327,8 @@ export class MessagesController {
                   type: 'object',
                   properties: {
                     id: { type: 'number', example: 33 },
-                    sender: { type: 'object', properties: {} },
-                    receiver: { type: 'object', properties: {} },
+                    sender: { type: 'string', example: '발신자 id' },
+                    receiver: { type: 'string', example: '수신자 id' },
                     content: { type: 'string', example: '안녕하세요' },
                     isRead: { type: 'boolean', example: false },
                     createdAt: {
@@ -505,8 +505,8 @@ export class MessagesController {
                 type: 'object',
                 properties: {
                   id: { type: 'number', example: 33 },
-                  sender: { type: 'object', properties: {} },
-                  receiver: { type: 'object', properties: {} },
+                  sender: { type: 'string', example: '발신자 id' },
+                  receiver: { type: 'string', example: '수신자 id' },
                   content: { type: 'string', example: '안녕하세요' },
                   isRead: { type: 'boolean', example: false },
                   createdAt: {

--- a/src/domain/messages/messages.service.ts
+++ b/src/domain/messages/messages.service.ts
@@ -158,7 +158,11 @@ export class MessagesService {
     rooms.forEach((room) => {
       const messagesLength = room.messages.length;
       if (messagesLength > 0) {
-        room['lastMessage'] = room.messages[messagesLength - 1].content;
+        const lastMessage = room.messages[messagesLength - 1];
+        room['lastMessage'] = {
+          content: lastMessage.content,
+          createdAt: lastMessage.createdAt,
+        };
       } else {
         room['lastMessage'] = null;
       }

--- a/src/domain/messages/messages.service.ts
+++ b/src/domain/messages/messages.service.ts
@@ -121,26 +121,8 @@ export class MessagesService {
       .withDeleted()
       .leftJoinAndSelect('messageRoom.messages', 'messages')
       .leftJoinAndSelect('messages.sender', 'sender')
-      .leftJoinAndSelect('sender.credential', 'sender_credential')
-      .leftJoinAndSelect('sender.profileItems', 'sender_profileItems')
-      .leftJoinAndSelect('sender_profileItems.emoji', 'sender_emoji')
-      .leftJoinAndSelect('sender_profileItems.wallpaper', 'sender_wallpaper')
-      .leftJoinAndSelect('sender_profileItems.background', 'sender_background')
-      .leftJoinAndSelect('sender_profileItems.frame', 'sender_frame')
       .withDeleted()
       .leftJoinAndSelect('messages.receiver', 'receiver')
-      .leftJoinAndSelect('receiver.credential', 'receiver_credential')
-      .leftJoinAndSelect('receiver.profileItems', 'receiver_profileItems')
-      .leftJoinAndSelect('receiver_profileItems.emoji', 'receiver_emoji')
-      .leftJoinAndSelect(
-        'receiver_profileItems.wallpaper',
-        'receiver_wallpaper',
-      )
-      .leftJoinAndSelect(
-        'receiver_profileItems.background',
-        'receiver_background',
-      )
-      .leftJoinAndSelect('receiver_profileItems.frame', 'receiver_frame')
       .withDeleted();
   }
 

--- a/src/domain/messages/messages.service.ts
+++ b/src/domain/messages/messages.service.ts
@@ -87,9 +87,9 @@ export class MessagesService {
     return messageRoom;
   }
 
-  // 채팅방 리스트 조회
-  async getRooms(user: User): Promise<MessageRoom[]> {
-    const rooms = await this.messageRoomRepository
+  // 공통 함수: 채팅방 쿼리 빌더 생성
+  private async createMessageRoomQueryBuilder() {
+    return this.messageRoomRepository
       .createQueryBuilder('messageRoom')
       .leftJoinAndSelect('messageRoom.firstUser', 'firstUser')
       .leftJoinAndSelect('firstUser.credential', 'firstUser_credential')
@@ -104,6 +104,7 @@ export class MessagesService {
         'firstUser_background',
       )
       .leftJoinAndSelect('firstUser_profileItems.frame', 'firstUser_frame')
+      .withDeleted()
       .leftJoinAndSelect('messageRoom.secondUser', 'secondUser')
       .leftJoinAndSelect('secondUser.credential', 'secondUser_credential')
       .leftJoinAndSelect('secondUser.profileItems', 'secondUser_profileItems')
@@ -117,15 +118,17 @@ export class MessagesService {
         'secondUser_background',
       )
       .leftJoinAndSelect('secondUser_profileItems.frame', 'secondUser_frame')
+      .withDeleted()
       .leftJoinAndSelect('messageRoom.messages', 'messages')
       .leftJoinAndSelect('messages.sender', 'sender')
-      .leftJoinAndSelect('messages.receiver', 'receiver')
       .leftJoinAndSelect('sender.credential', 'sender_credential')
       .leftJoinAndSelect('sender.profileItems', 'sender_profileItems')
       .leftJoinAndSelect('sender_profileItems.emoji', 'sender_emoji')
       .leftJoinAndSelect('sender_profileItems.wallpaper', 'sender_wallpaper')
       .leftJoinAndSelect('sender_profileItems.background', 'sender_background')
       .leftJoinAndSelect('sender_profileItems.frame', 'sender_frame')
+      .withDeleted()
+      .leftJoinAndSelect('messages.receiver', 'receiver')
       .leftJoinAndSelect('receiver.credential', 'receiver_credential')
       .leftJoinAndSelect('receiver.profileItems', 'receiver_profileItems')
       .leftJoinAndSelect('receiver_profileItems.emoji', 'receiver_emoji')
@@ -138,6 +141,13 @@ export class MessagesService {
         'receiver_background',
       )
       .leftJoinAndSelect('receiver_profileItems.frame', 'receiver_frame')
+      .withDeleted();
+  }
+
+  // 채팅방 리스트 조회
+  async getRooms(user: User): Promise<MessageRoom[]> {
+    const queryBuilder = await this.createMessageRoomQueryBuilder();
+    const rooms = await queryBuilder
       .where('firstUser.id = :userId OR secondUser.id = :userId', {
         userId: user.id,
       })
@@ -168,58 +178,12 @@ export class MessagesService {
 
   // 채팅방 조회
   async getRoom(id: number, user: User): Promise<MessageRoom> {
-    const messageRoom = await this.messageRoomRepository
-      .createQueryBuilder('messageRoom')
-      .leftJoinAndSelect('messageRoom.firstUser', 'firstUser')
-      .leftJoinAndSelect('firstUser.credential', 'firstUser_credential')
-      .leftJoinAndSelect('firstUser.profileItems', 'firstUser_profileItems')
-      .leftJoinAndSelect('firstUser_profileItems.emoji', 'firstUser_emoji')
-      .leftJoinAndSelect(
-        'firstUser_profileItems.wallpaper',
-        'firstUser_wallpaper',
-      )
-      .leftJoinAndSelect(
-        'firstUser_profileItems.background',
-        'firstUser_background',
-      )
-      .leftJoinAndSelect('firstUser_profileItems.frame', 'firstUser_frame')
-      .leftJoinAndSelect('messageRoom.secondUser', 'secondUser')
-      .leftJoinAndSelect('secondUser.credential', 'secondUser_credential')
-      .leftJoinAndSelect('secondUser.profileItems', 'secondUser_profileItems')
-      .leftJoinAndSelect('secondUser_profileItems.emoji', 'secondUser_emoji')
-      .leftJoinAndSelect(
-        'secondUser_profileItems.wallpaper',
-        'secondUser_wallpaper',
-      )
-      .leftJoinAndSelect(
-        'secondUser_profileItems.background',
-        'secondUser_background',
-      )
-      .leftJoinAndSelect('secondUser_profileItems.frame', 'secondUser_frame')
-      .leftJoinAndSelect('messageRoom.messages', 'messages')
-      .leftJoinAndSelect('messages.sender', 'sender')
-      .leftJoinAndSelect('messages.receiver', 'receiver')
-      .leftJoinAndSelect('sender.credential', 'sender_credential')
-      .leftJoinAndSelect('sender.profileItems', 'sender_profileItems')
-      .leftJoinAndSelect('sender_profileItems.emoji', 'sender_emoji')
-      .leftJoinAndSelect('sender_profileItems.wallpaper', 'sender_wallpaper')
-      .leftJoinAndSelect('sender_profileItems.background', 'sender_background')
-      .leftJoinAndSelect('sender_profileItems.frame', 'sender_frame')
-      .leftJoinAndSelect('receiver.credential', 'receiver_credential')
-      .leftJoinAndSelect('receiver.profileItems', 'receiver_profileItems')
-      .leftJoinAndSelect('receiver_profileItems.emoji', 'receiver_emoji')
-      .leftJoinAndSelect(
-        'receiver_profileItems.wallpaper',
-        'receiver_wallpaper',
-      )
-      .leftJoinAndSelect(
-        'receiver_profileItems.background',
-        'receiver_background',
-      )
-      .leftJoinAndSelect('receiver_profileItems.frame', 'receiver_frame')
+    const queryBuilder = await this.createMessageRoomQueryBuilder();
+    const messageRoom = await queryBuilder
       .where('messageRoom.id = :id', { id })
       .orderBy('messages.createdAt', 'ASC')
       .getOne();
+
     if (!messageRoom) {
       throw new MessageRoomNotFoundException('채팅방을 찾을 수 없습니다.');
     }


### PR DESCRIPTION
## #️⃣연관된 이슈
#55 
> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- messageRoom 쿼리빌더를 공통함수로 뺐습니다.
- 채팅방 목록 조회 시 마지막 메세지 정보에 content만 보내고 있었는데 createdAt도 추가했습니다.
- messageRoom에 있는 firstUser, secondUser에서 이미 필요한 유저 정보를 자세히 전달하고 있기 때문에 message에 있는 sender, receiver는 유저 id만 보낼 수 있도록 수정했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
