### PR TITLE
Feat: 차단기능 추가 #99

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -24,6 +24,7 @@ import { SearchHistoriesModule } from '@/domain/search-histories/search-historie
 import { FeedbacksModule } from '@/domain/feedbacks/feedbacks.module';
 import { NotificationModule } from './notification/notification.module';
 import { SearchModule } from '@/domain/search/search.module';
+import { BlocksModule } from './domain/blocks/blocks.module';
 
 @Module({
   imports: [
@@ -61,6 +62,7 @@ import { SearchModule } from '@/domain/search/search.module';
     FeedbacksModule,
     NotificationModule,
     SearchModule,
+    BlocksModule,
   ],
   controllers: [AppController, HealthCheckController],
   providers: [AppService],

--- a/src/domain/authentication/exceptions/authentication.exception.ts
+++ b/src/domain/authentication/exceptions/authentication.exception.ts
@@ -26,3 +26,9 @@ export class UserReportForbiddenException extends BaseException {
     super(AuthExceptionEnum.REPORT_FORBIDDEN, HttpStatus.FORBIDDEN, message);
   }
 }
+
+export class UserBlockForbiddenException extends BaseException {
+  constructor(message: string) {
+    super(AuthExceptionEnum.BLOCK_FORBIDDEN, HttpStatus.FORBIDDEN, message);
+  }
+}

--- a/src/domain/blocks/blocks.controller.ts
+++ b/src/domain/blocks/blocks.controller.ts
@@ -13,6 +13,7 @@ import {
 import { BlocksService } from './blocks.service';
 import { CreateBlockUserDto } from './dto/create-block-user.dto';
 import {
+  ApiBadRequestResponse,
   ApiNotFoundResponse,
   ApiOperation,
   ApiResponse,
@@ -27,6 +28,7 @@ import { PageDto } from '@/common/dto/page/page.dto';
 import { PageMetaDto } from '@/common/dto/page/page-meta.dto';
 import { PageOptionsDto } from '@/common/dto/page/page-options.dto';
 import { PaginationSuccessResponse } from '@/common/decorators/pagination-success-response.decorator';
+import { BlockBadRequestException } from './exceptions/block.exception';
 
 @Controller('blocks')
 @ApiTags('blocks')
@@ -39,11 +41,20 @@ export class BlocksController {
   @ApiResponse({
     status: 201,
     description: '차단 성공',
-    type: BlockResponseDto,
+    schema: {
+      type: 'object',
+      properties: {
+        createdAt: { type: 'string', format: 'date-time' },
+      },
+    },
   })
   @ApiNotFoundResponse({
     type: UserNotFoundException,
-    description: '사용자를 찾을 수 없습니다',
+    description: '사용자를 찾을 수 없습니다.',
+  })
+  @ApiBadRequestResponse({
+    type: BlockBadRequestException,
+    description: '이미 차단된 사용자입니다.',
   })
   async createBlock(
     @Req() req: RequestWithUser,

--- a/src/domain/blocks/blocks.controller.ts
+++ b/src/domain/blocks/blocks.controller.ts
@@ -1,0 +1,136 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Delete,
+  UseGuards,
+  Req,
+  Query,
+  HttpStatus,
+} from '@nestjs/common';
+import { BlocksService } from './blocks.service';
+import { CreateBlockUserDto } from './dto/create-block-user.dto';
+import {
+  ApiNotFoundResponse,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthenticationGuard } from '../authentication/guards/jwt-authentication.guard';
+import RequestWithUser from '../authentication/interfaces/request-with-user.interface';
+import { UserNotFoundException } from '../users/exceptions/users.exception';
+import { BlockResponseDto } from './dto/block-response.dto';
+import { HttpResponse } from '@/@types/http-response';
+import { PageDto } from '@/common/dto/page/page.dto';
+import { PageMetaDto } from '@/common/dto/page/page-meta.dto';
+import { PageOptionsDto } from '@/common/dto/page/page-options.dto';
+import { PaginationSuccessResponse } from '@/common/decorators/pagination-success-response.decorator';
+
+@Controller('blocks')
+@ApiTags('blocks')
+export class BlocksController {
+  constructor(private readonly blocksService: BlocksService) {}
+
+  @Post()
+  @UseGuards(JwtAuthenticationGuard)
+  @ApiOperation({ summary: '유저 차단' })
+  @ApiResponse({
+    status: 201,
+    description: '차단 성공',
+    type: BlockResponseDto,
+  })
+  @ApiNotFoundResponse({
+    type: UserNotFoundException,
+    description: '사용자를 찾을 수 없습니다',
+  })
+  async createBlock(
+    @Req() req: RequestWithUser,
+    @Body() createBlockUserDto: CreateBlockUserDto,
+  ) {
+    const { blockedUserId } = createBlockUserDto;
+    const block = await this.blocksService.createBlock(req.user, blockedUserId);
+    return HttpResponse.created('유저 차단이 완료되었습니다.', block.createdAt);
+  }
+
+  @Get('users/:userId')
+  @UseGuards(JwtAuthenticationGuard)
+  @ApiOperation({ summary: '해당 유저가 차단한 목록 조회 (관리자)' })
+  @PaginationSuccessResponse(HttpStatus.OK, {
+    model: PageDto,
+    message: '유저가 차단한 목록 조회에 성공했습니다.',
+    generic: BlockResponseDto,
+  })
+  async getBlockedUsers(
+    @Req() req: RequestWithUser,
+    @Param('userId') blockedBy: string,
+    @Query() pageOptionsDto: PageOptionsDto,
+  ) {
+    const { blocks, total } = await this.blocksService.getBlockedUsers(
+      req.user,
+      blockedBy,
+      pageOptionsDto,
+    );
+    const { data, meta } = new PageDto(
+      blocks.map((block) => new BlockResponseDto(block)),
+      new PageMetaDto(pageOptionsDto, total),
+    );
+    return HttpResponse.success(
+      '유저가 차단한 목록 조회에 성공했습니다.',
+      data,
+      meta,
+    );
+  }
+
+  @Get()
+  @UseGuards(JwtAuthenticationGuard)
+  @ApiOperation({ summary: '유저 차단 전체 조회 (관리자)' })
+  @PaginationSuccessResponse(HttpStatus.OK, {
+    model: PageDto,
+    message: '차단 전체 조회에 성공했습니다',
+    generic: BlockResponseDto,
+  })
+  async findAll(
+    @Req() req: RequestWithUser,
+    @Query() pageOptionsDto: PageOptionsDto,
+  ) {
+    const { blocks, total } = await this.blocksService.findAll(
+      req.user,
+      pageOptionsDto,
+    );
+    const { data, meta } = new PageDto(
+      blocks.map((block) => new BlockResponseDto(block)),
+      new PageMetaDto(pageOptionsDto, total),
+    );
+    return HttpResponse.success('차단 전체 조회에 성공했습니다.', data, meta);
+  }
+
+  @Get(':id')
+  @UseGuards(JwtAuthenticationGuard)
+  @ApiOperation({ summary: '유저 차단 단일 조회 (관리자)' })
+  @ApiResponse({
+    status: 200,
+    description: '차단 단일 조회에 성공했습니다.',
+    type: BlockResponseDto,
+  })
+  async findOne(@Req() req: RequestWithUser, @Param('id') id: string) {
+    const block = await this.blocksService.findOne(req.user, +id);
+    return HttpResponse.success(
+      '차단 단일 조회에 성공했습니다.',
+      new BlockResponseDto(block),
+    );
+  }
+
+  @Delete(':id')
+  @UseGuards(JwtAuthenticationGuard)
+  @ApiOperation({ summary: '유저 차단 삭제' })
+  @ApiResponse({
+    status: 200,
+    description: '차단이 삭제되었습니다.',
+  })
+  async remove(@Req() req: RequestWithUser, @Param('id') id: string) {
+    await this.blocksService.remove(req.user, +id);
+    return HttpResponse.success('차단이 삭제되었습니다.');
+  }
+}

--- a/src/domain/blocks/blocks.module.ts
+++ b/src/domain/blocks/blocks.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { BlocksService } from './blocks.service';
+import { BlocksController } from './blocks.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { BlockUser } from './entities/block.entity';
+import { UsersModule } from '../users/users.module';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([BlockUser]), UsersModule],
+  controllers: [BlocksController],
+  providers: [BlocksService],
+})
+export class BlocksModule {}

--- a/src/domain/blocks/blocks.service.ts
+++ b/src/domain/blocks/blocks.service.ts
@@ -1,0 +1,129 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { BlockUser } from './entities/block.entity';
+import { UsersService } from '../users/users.service';
+import { Repository } from 'typeorm';
+import { PageOptionsDto } from '@/common/dto/page/page-options.dto';
+import { User } from '../users/entities/user.entity';
+import { AuthorityName } from '@/@types/enum/user.enum';
+import { UserBlockForbiddenException } from '../authentication/exceptions/authentication.exception';
+import {
+  BlockBadRequestException,
+  BlockNotFoundException,
+} from './exceptions/block.exception';
+
+@Injectable()
+export class BlocksService {
+  constructor(
+    @InjectRepository(BlockUser)
+    private readonly blockUserRepository: Repository<BlockUser>,
+    private readonly usersService: UsersService,
+  ) {}
+
+  async createBlock(user: User, blockedUserId: string): Promise<BlockUser> {
+    await this.usersService.findById(blockedUserId);
+
+    if (user.id === blockedUserId) {
+      throw new BlockBadRequestException('자기 자신을 차단할 수 없습니다.');
+    }
+    const blockedUsers = user.blockedUsers.map((block) => block.blockedUser.id);
+    if (blockedUsers.includes(blockedUserId)) {
+      throw new BlockBadRequestException('이미 차단된 사용자입니다.');
+    }
+
+    const block = this.blockUserRepository.create({
+      blockedBy: { id: user.id },
+      blockedUser: { id: blockedUserId },
+    });
+    const blocked = await this.blockUserRepository.save(block);
+
+    return blocked;
+  }
+
+  async getBlockedUsers(
+    user: User,
+    blockedBy: string,
+    pageOptionsDto: PageOptionsDto,
+  ): Promise<{ blocks: BlockUser[]; total: number }> {
+    const { page, pageSize } = pageOptionsDto;
+    if (!this.isAdmin(user))
+      throw new UserBlockForbiddenException('접근 권한이 없습니다');
+
+    const queryBuilder = await this.findBlocks();
+    let blocks: BlockUser[], total: number;
+
+    if (page && pageSize) {
+      [blocks, total] = await queryBuilder
+        .andWhere('blockedBy.id = :blockedBy', { blockedBy })
+        .skip(pageSize * (page - 1))
+        .take(pageSize)
+        .getManyAndCount();
+    } else {
+      blocks = await queryBuilder
+        .andWhere('blockedBy.id = :blockedBy', { blockedBy })
+        .getMany();
+      total = blocks.length;
+    }
+
+    return { blocks, total };
+  }
+
+  async findAll(
+    user: User,
+    pageOptionsDto: PageOptionsDto,
+  ): Promise<{ blocks: BlockUser[]; total: number }> {
+    const { page, pageSize } = pageOptionsDto;
+    if (!this.isAdmin(user))
+      throw new UserBlockForbiddenException('접근 권한이 없습니다');
+
+    const queryBuilder = await this.findBlocks();
+    let blocks: BlockUser[], total: number;
+
+    if (page && pageSize) {
+      [blocks, total] = await queryBuilder
+        .skip(pageSize * (page - 1))
+        .take(pageSize)
+        .getManyAndCount();
+    } else {
+      blocks = await queryBuilder.getMany();
+      total = blocks.length;
+    }
+
+    return { blocks, total };
+  }
+
+  async findOne(user: User, id: number): Promise<BlockUser> {
+    if (!this.isAdmin(user))
+      throw new UserBlockForbiddenException('접근 권한이 없습니다');
+
+    const queryBuilder = await this.findBlocks();
+    const block = await queryBuilder
+      .andWhere('block.id = :id', { id })
+      .getOne();
+    if (!block) {
+      throw new BlockNotFoundException('해당 차단을 찾을 수 없습니다.');
+    }
+
+    return block;
+  }
+
+  async remove(user: User, id: number): Promise<void> {
+    const block = await this.findOne(user, id);
+    await this.blockUserRepository.delete(block.id);
+  }
+
+  private async findBlocks() {
+    return this.blockUserRepository
+      .createQueryBuilder('block')
+      .leftJoinAndSelect('block.blockedBy', 'blockedBy')
+      .leftJoinAndSelect('blockedBy.credential', 'blockedBy_credential')
+      .leftJoinAndSelect('block.blockedUser', 'blockedUser')
+      .leftJoinAndSelect('blockedUser.credential', 'blockedUser_credential');
+  }
+
+  private isAdmin(user: User): boolean {
+    return user.authorities.some(
+      (authority) => authority.authorityName === AuthorityName.ADMIN,
+    );
+  }
+}

--- a/src/domain/blocks/dto/block-response.dto.ts
+++ b/src/domain/blocks/dto/block-response.dto.ts
@@ -7,11 +7,11 @@ export class BlockResponseDto {
   @Expose()
   readonly id: number;
 
-  @ApiProperty({ type: Object, description: '차단한 유저 정보' })
+  @ApiProperty({ type: Object, description: '차단한 유저 정보(id, nickname)' })
   @Expose()
   readonly blockedBy: { id: string; nickname: string };
 
-  @ApiProperty({ type: Object, description: '차단된 유저 정보' })
+  @ApiProperty({ type: Object, description: '차단된 유저 정보(id, nickname)' })
   @Expose()
   readonly blockedUser: { id: string; nickname: string };
 

--- a/src/domain/blocks/dto/block-response.dto.ts
+++ b/src/domain/blocks/dto/block-response.dto.ts
@@ -1,0 +1,34 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import { BlockUser } from '../entities/block.entity';
+
+export class BlockResponseDto {
+  @ApiProperty({ type: Number, description: '차단 ID' })
+  @Expose()
+  readonly id: number;
+
+  @ApiProperty({ type: Object, description: '차단한 유저 정보' })
+  @Expose()
+  readonly blockedBy: { id: string; nickname: string };
+
+  @ApiProperty({ type: Object, description: '차단된 유저 정보' })
+  @Expose()
+  readonly blockedUser: { id: string; nickname: string };
+
+  @ApiProperty({ type: Date, description: '차단 날짜, 시간' })
+  @Expose()
+  readonly createdAt: Date;
+
+  constructor(blockUser: BlockUser) {
+    this.id = blockUser.id;
+    this.blockedBy = {
+      id: blockUser.blockedBy.id,
+      nickname: blockUser.blockedBy.credential.nickname,
+    };
+    this.blockedUser = {
+      id: blockUser.blockedUser.id,
+      nickname: blockUser.blockedUser.credential.nickname,
+    };
+    this.createdAt = blockUser.createdAt;
+  }
+}

--- a/src/domain/blocks/dto/create-block-user.dto.ts
+++ b/src/domain/blocks/dto/create-block-user.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateBlockUserDto {
+  @ApiProperty({
+    example: '77e88f4b-5ff5-47f9-9b3b-b1757c491cbb',
+    description: '차단할 유저 ',
+    required: true,
+  })
+  @IsString()
+  @IsNotEmpty()
+  blockedUserId: string;
+}

--- a/src/domain/blocks/entities/block.entity.ts
+++ b/src/domain/blocks/entities/block.entity.ts
@@ -1,0 +1,25 @@
+import { User } from '@/domain/users/entities/user.entity';
+import {
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+@Entity({ name: 'blocks' })
+export class BlockUser {
+  @PrimaryGeneratedColumn('increment')
+  id: number;
+
+  @ManyToOne('User', 'blockedUsers', { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'blocked_by' })
+  blockedBy: User;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'blocked_user' })
+  blockedUser: User;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+}

--- a/src/domain/blocks/exceptions/block.exception.ts
+++ b/src/domain/blocks/exceptions/block.exception.ts
@@ -1,0 +1,19 @@
+import { BaseException } from '@/lib/exceptions/base.exception';
+import { BlockExceptionEnum } from '@/lib/exceptions/exception.enum';
+import { HttpStatus } from '@nestjs/common';
+
+export class BlockBadRequestException extends BaseException {
+  constructor(message: string) {
+    super(
+      BlockExceptionEnum.BLOCK_BAD_REQUEST,
+      HttpStatus.BAD_REQUEST,
+      message,
+    );
+  }
+}
+
+export class BlockNotFoundException extends BaseException {
+  constructor(message: string) {
+    super(BlockExceptionEnum.BLOCK_NOT_FOUND, HttpStatus.NOT_FOUND, message);
+  }
+}

--- a/src/domain/users/entities/user.entity.ts
+++ b/src/domain/users/entities/user.entity.ts
@@ -16,6 +16,7 @@ import { Post } from '@/domain/posts/entities/post.entity';
 import { ItemCart } from '@/domain/items/entities/item-cart.entity';
 import { ProfileItems } from './profile-items.entity';
 import { MessageRoom } from '@/domain/messages/entities/message-room.entity';
+import { BlockUser } from '@/domain/blocks/entities/block.entity';
 
 @Entity({ name: 'users' })
 export class User {
@@ -93,6 +94,9 @@ export class User {
 
   @OneToMany('ItemCart', 'user', { cascade: true })
   itemCart: ItemCart[];
+
+  @OneToMany('BlockUser', 'blockedBy', { cascade: true })
+  blockedUsers: BlockUser[]; // 유저가 차단한 다른 유저들의 목록
 
   // @OneToMany(() => Sticker, (stickers) => stickers.user)
   // givenStickers: Sticker[];

--- a/src/domain/users/users.service.ts
+++ b/src/domain/users/users.service.ts
@@ -195,6 +195,9 @@ export class UsersService {
         'profileItems.background',
         'profileItems.wallpaper',
         'profileItems.frame',
+        'blockedUsers',
+        'blockedUsers.blockedBy',
+        'blockedUsers.blockedUser',
       ],
     });
     if (!user) {

--- a/src/lib/exceptions/exception.enum.ts
+++ b/src/lib/exceptions/exception.enum.ts
@@ -54,6 +54,7 @@ export enum AuthExceptionEnum {
   USER_UNAUTHORIZED = '4010',
   SOCIAL_LOGIN_FORBIDDEN = '4030',
   REPORT_FORBIDDEN = '4031',
+  BLOCK_FORBIDDEN = '4032',
 }
 
 export enum UserExceptionEnum {
@@ -87,4 +88,9 @@ export enum SearchHistoryExceptionEnum {
 export enum FeedbackExceptionEnum {
   NOT_ADMIN_NO_PERMISSION = '8030',
   FEEDBACK_NOT_FOUND = '8040',
+}
+
+export enum BlockExceptionEnum {
+  BLOCK_BAD_REQUEST = '9000',
+  BLOCK_NOT_FOUND = '9010',
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#99 
> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 유저 차단 기능을 추가했습니다.
- 유저의 id로 차단 목록 조회, 전체 차단 목록 조회, 단일 차단 조회, 차단 삭제 기능을 추가했습니다. (관리자 권한)
- 게시글, 댓글, 채팅방 리스트 조회 시 작성자나 상대가 차단한 유저라면 해당 항목을 보이지 않게 하는 것이 좋을 것 같아서 가드는 어려울 것 같고, 각 리스트 조회 시 차단한 유저의 항목을 찾아서 데이터를 보내지 않거나, 프론트 측에서 보이지 않게 설정할 수 있도록 구분하는 필드를 넣는게 좋을것 같다고 생각했습니다! 다른 생각이 있다면 말씀해주세요

- 예를 들어서 아래와 같은 느낌으로 차단 항목을 찾는 건데, 게시글의 경우에는 회원과 비회원 모두 볼 수 있게 되어있어서 쿠키의 존재 여부를 확인한 뒤 유저가 인증되면 차단항목을 찾고, 그렇지 않고 비회원이라면 전체 게시글을 보여주는 방식이 될 것 같아서 좀 더 복잡하긴 할 것 같습니다,,ㅠㅠ 좋은 생각 있다면 말씀해주세요!

```typescript
const blockedUsers = user.blockedUsers.map(block => block.blockedUser.id);

const posts = await this.postsRepository.find();

  posts.forEach(post => {
    if (blockedUsers.includes(post.author.id)) {
      post.isBlockedByUser = true;
    } else {
      post.isBlockedByUser = false;
    }
  });
```

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
