### PR TITLE
user entity에 blockingUsers 추가, 쪽지기능 차단유저 처리 추가

### DIFF
--- a/src/domain/messages/messages.controller.ts
+++ b/src/domain/messages/messages.controller.ts
@@ -10,12 +10,20 @@ import {
 } from '@nestjs/common';
 import { MessagesService } from './messages.service';
 import { CreateMessageDto } from './dto/create-message.dto';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBadRequestResponse,
+  ApiForbiddenResponse,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { JwtAuthenticationGuard } from '../authentication/guards/jwt-authentication.guard';
 import { HttpResponse } from '@/@types/http-response';
 import RequestWithUser from '../authentication/interfaces/request-with-user.interface';
 import { MessageResponseDto } from './dto/message-response.dto';
 import { UserProfileDto } from '../users/dto/user-profile.dto';
+import { UserBlockForbiddenException } from '../authentication/exceptions/authentication.exception';
+import { MessageBadRequestException } from './exceptions/message.exception';
 
 @Controller('messages')
 @ApiTags('messages')
@@ -169,9 +177,13 @@ export class MessagesController {
       },
     },
   })
-  @ApiResponse({
-    status: 400,
+  @ApiBadRequestResponse({
+    type: MessageBadRequestException,
     description: '쪽지 내용을 제공해야 합니다.',
+  })
+  @ApiForbiddenResponse({
+    type: UserBlockForbiddenException,
+    description: '차단한 유저에게 쪽지를 보낼 수 없습니다.',
   })
   async sendMessage(
     @Body() createMessageDto: CreateMessageDto,
@@ -522,6 +534,7 @@ export class MessagesController {
                 },
               },
             },
+            isBlockedUser: { type: 'boolean', example: false },
           },
         },
       },

--- a/src/domain/users/entities/user.entity.ts
+++ b/src/domain/users/entities/user.entity.ts
@@ -98,6 +98,9 @@ export class User {
   @OneToMany('BlockUser', 'blockedBy', { cascade: true })
   blockedUsers: BlockUser[]; // 유저가 차단한 다른 유저들의 목록
 
+  @OneToMany('BlockUser', 'blockedUser', { cascade: true })
+  blockingUsers: BlockUser[]; // 유저를 차단한 다른 유저들의 목록
+
   // @OneToMany(() => Sticker, (stickers) => stickers.user)
   // givenStickers: Sticker[];
 

--- a/src/domain/users/users.service.ts
+++ b/src/domain/users/users.service.ts
@@ -196,8 +196,8 @@ export class UsersService {
         'profileItems.wallpaper',
         'profileItems.frame',
         'blockedUsers',
-        'blockedUsers.blockedBy',
         'blockedUsers.blockedUser',
+        'blockingUsers.blockedBy',
       ],
     });
     if (!user) {


### PR DESCRIPTION
## #️⃣연관된 이슈
#110 
> ex) #이슈번호, #이슈번호

## 📝작업 내용
### 차단 시
- 채팅방은 사라지지 않음
- 차단한 유저는 차단된 유저에게 오는 쪽지를 더 볼 수 없음, 차단한 유저의 채팅방에서 쪽지를 더 보낼 수 없음. ('차단한 유저입니다' 문구 출력하면서 disable 처리)
- 차단된 유저는 차단한 유저에게 차단된 것을 모름, 여전히 메세지를 보낼 수 있음
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 채팅방 리스트에서도 leaveRoom추가된 messages는 걸러냄
- user entity에 blockingUsers 추가(나를 차단한 유저 blockingUsers.blockedBy로 알 수 있음), 내가 차단한 유저는 user.blockedUsers.blockedUser -> 차단 처리 로직 작성 시 참고해주세요!
- getRoom: 채팅방 정보에 상대유저가 차단한 상대인지 여부 보내기 isBlockedUser: true
- sendMessage: 상대가 자신이 차단한 유저일 경우 오류(UserBlockForbiddenException)
- sendMessage: 차단당했는지 여부를 확인 후에 차단당했으면 메세지의 leaveRoom에 차단한 유저 id 담기

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
