### PR TITLE
roles guard 추가, items, reports, blocks에 적용

### DIFF
--- a/src/domain/authentication/decorators/role.decorator.ts
+++ b/src/domain/authentication/decorators/role.decorator.ts
@@ -1,0 +1,6 @@
+import { AuthorityName } from '@/@types/enum/user.enum';
+import { SetMetadata } from '@nestjs/common';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: AuthorityName[]) =>
+  SetMetadata(ROLES_KEY, roles);

--- a/src/domain/authentication/exceptions/authentication.exception.ts
+++ b/src/domain/authentication/exceptions/authentication.exception.ts
@@ -21,6 +21,12 @@ export class UserUnauthorizedException extends BaseException {
   }
 }
 
+export class UserForbiddenException extends BaseException {
+  constructor(message: string) {
+    super(AuthExceptionEnum.USER_FORBIDDEN, HttpStatus.FORBIDDEN, message);
+  }
+}
+
 export class UserReportForbiddenException extends BaseException {
   constructor(message: string) {
     super(AuthExceptionEnum.REPORT_FORBIDDEN, HttpStatus.FORBIDDEN, message);

--- a/src/domain/authentication/guards/roles.guard.ts
+++ b/src/domain/authentication/guards/roles.guard.ts
@@ -13,13 +13,11 @@ export class RolesGuard implements CanActivate {
       ROLES_KEY,
       [context.getHandler(), context.getClass()],
     );
-    console.log(requiredRole);
     if (!requiredRole) {
       return true;
     }
-    const { user } = context.switchToHttp().getRequest();
-    console.log(user);
 
+    const { user } = context.switchToHttp().getRequest();
     if (
       !user.authorities.some((authority) =>
         requiredRole.includes(authority.authorityName),

--- a/src/domain/authentication/guards/roles.guard.ts
+++ b/src/domain/authentication/guards/roles.guard.ts
@@ -1,0 +1,33 @@
+import { AuthorityName } from '@/@types/enum/user.enum';
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ROLES_KEY } from '../decorators/role.decorator';
+import { UserForbiddenException } from '../exceptions/authentication.exception';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const requiredRole = this.reflector.getAllAndOverride<AuthorityName[]>(
+      ROLES_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+    console.log(requiredRole);
+    if (!requiredRole) {
+      return true;
+    }
+    const { user } = context.switchToHttp().getRequest();
+    console.log(user);
+
+    if (
+      !user.authorities.some((authority) =>
+        requiredRole.includes(authority.authorityName),
+      )
+    ) {
+      throw new UserForbiddenException('접근 권한이 없습니다.');
+    }
+
+    return true;
+  }
+}

--- a/src/domain/items/items.controller.ts
+++ b/src/domain/items/items.controller.ts
@@ -19,6 +19,9 @@ import RequestWithUser from '../authentication/interfaces/request-with-user.inte
 import { JwtAuthenticationGuard } from '../authentication/guards/jwt-authentication.guard';
 import { Animal } from '@/@types/enum/animal.enum';
 import { HttpResponse } from '@/@types/http-response';
+import { RolesGuard } from '../authentication/guards/roles.guard';
+import { Roles } from '../authentication/decorators/role.decorator';
+import { AuthorityName } from '@/@types/enum/user.enum';
 
 @Controller('items')
 @ApiTags('items')
@@ -568,6 +571,8 @@ export class ItemsController {
 
   /* 관리자 페이지 */
   @Post()
+  @UseGuards(JwtAuthenticationGuard, RolesGuard)
+  @Roles(AuthorityName.ADMIN)
   @ApiOperation({ summary: '아이템 생성(관리자)' })
   @ApiResponse({
     status: 201,
@@ -604,6 +609,8 @@ export class ItemsController {
   }
 
   @Get('/admins')
+  @UseGuards(JwtAuthenticationGuard, RolesGuard)
+  @Roles(AuthorityName.ADMIN)
   @ApiOperation({ summary: '전체 아이템 조회(관리자)' })
   @ApiResponse({
     status: 200,
@@ -643,6 +650,8 @@ export class ItemsController {
   }
 
   @Get('/admins/:id')
+  @UseGuards(JwtAuthenticationGuard, RolesGuard)
+  @Roles(AuthorityName.ADMIN)
   @ApiOperation({ summary: '아이템 상세 조회(관리자)' })
   @ApiResponse({
     status: 200,
@@ -683,6 +692,8 @@ export class ItemsController {
   }
 
   @Patch('/admins/:id')
+  @UseGuards(JwtAuthenticationGuard, RolesGuard)
+  @Roles(AuthorityName.ADMIN)
   @ApiOperation({ summary: '아이템 수정(관리자)' })
   @ApiResponse({
     status: 200,
@@ -719,6 +730,8 @@ export class ItemsController {
   }
 
   @Delete('/admins/:id')
+  @UseGuards(JwtAuthenticationGuard, RolesGuard)
+  @Roles(AuthorityName.ADMIN)
   @ApiOperation({ summary: '아이템 삭제(관리자)' })
   @ApiResponse({
     status: 200,

--- a/src/domain/reports/reports.controller.ts
+++ b/src/domain/reports/reports.controller.ts
@@ -33,6 +33,9 @@ import {
   MessageNotFoundException,
   MessageRoomNotFoundException,
 } from '../messages/exceptions/message.exception';
+import { RolesGuard } from '../authentication/guards/roles.guard';
+import { AuthorityName } from '@/@types/enum/user.enum';
+import { Roles } from '../authentication/decorators/role.decorator';
 
 @ApiTags('reports')
 @Controller('reports')
@@ -167,17 +170,12 @@ export class ReportsController {
     message: '신고 전체 조회에 성공했습니다',
     generic: ReportResponseDto,
   })
-  @UseGuards(JwtAuthenticationGuard)
   @Get()
-  async findAll(
-    @Req() req: RequestWithUser,
-    @Query() pageOptionsDto: PageOptionsDto,
-  ) {
-    const { user } = req;
-    const { reports, total } = await this.reportsService.findAll(
-      user,
-      pageOptionsDto,
-    );
+  @UseGuards(JwtAuthenticationGuard, RolesGuard)
+  @Roles(AuthorityName.ADMIN)
+  async findAll(@Query() pageOptionsDto: PageOptionsDto) {
+    const { reports, total } =
+      await this.reportsService.findAll(pageOptionsDto);
     const { data, meta } = new PageDto(
       reports.map((report) => new ReportResponseDto(report)),
       new PageMetaDto(pageOptionsDto, total),
@@ -192,11 +190,11 @@ export class ReportsController {
     description: '조회 성공',
     type: ReportResponseDto,
   })
-  @UseGuards(JwtAuthenticationGuard)
   @Get(':id')
-  async findOne(@Req() req: RequestWithUser, @Param('id') id: string) {
-    const { user } = req;
-    const report = await this.reportsService.findOne(user, +id);
+  @UseGuards(JwtAuthenticationGuard, RolesGuard)
+  @Roles(AuthorityName.ADMIN)
+  async findOne(@Param('id') id: string) {
+    const report = await this.reportsService.findOne(+id);
 
     return HttpResponse.success('조회 성공', new ReportResponseDto(report));
   }

--- a/src/domain/reports/reports.service.ts
+++ b/src/domain/reports/reports.service.ts
@@ -6,8 +6,6 @@ import { PostsService } from '@/domain/posts/posts.service';
 import { CommentsService } from '@/domain/comments/comments.service';
 import { Report } from '@/domain/reports/entities/report.entity';
 import { User } from '@/domain/users/entities/user.entity';
-import { AuthorityName } from '@/@types/enum/user.enum';
-import { UserReportForbiddenException } from '@/domain/authentication/exceptions/authentication.exception';
 import { PageOptionsDto } from '@/common/dto/page/page-options.dto';
 import { MessagesService } from '../messages/messages.service';
 import { MessageBadRequestException } from '../messages/exceptions/message.exception';
@@ -21,12 +19,6 @@ export class ReportsService {
     private readonly commentsService: CommentsService,
     private readonly messagesService: MessagesService,
   ) {}
-
-  private isAdmin(user: User): boolean {
-    return user.authorities.some(
-      (authority) => authority.authorityName === AuthorityName.ADMIN,
-    );
-  }
 
   private async findReports() {
     return this.reportsRepository
@@ -97,10 +89,8 @@ export class ReportsService {
     return await this.reportsRepository.save(messageReport);
   }
 
-  async findAll(user: User, pageOptionsDto: PageOptionsDto) {
+  async findAll(pageOptionsDto: PageOptionsDto) {
     const { page, pageSize } = pageOptionsDto;
-    if (!this.isAdmin(user))
-      throw new UserReportForbiddenException('접근 권한이 없습니다');
 
     const queryBuilder = await this.findReports();
     let reports: Report[], total: number;
@@ -118,10 +108,7 @@ export class ReportsService {
     return { reports, total };
   }
 
-  async findOne(user: User, id: number) {
-    if (!this.isAdmin(user))
-      throw new UserReportForbiddenException('접근 권한이 없습니다');
-
+  async findOne(id: number) {
     const queryBuilder = await this.findReports();
     return queryBuilder.andWhere('reports.id = :id', { id }).getOne();
   }

--- a/src/lib/exceptions/exception.enum.ts
+++ b/src/lib/exceptions/exception.enum.ts
@@ -52,9 +52,10 @@ export enum StickerExceptionEnum {
 
 export enum AuthExceptionEnum {
   USER_UNAUTHORIZED = '4010',
-  SOCIAL_LOGIN_FORBIDDEN = '4030',
-  REPORT_FORBIDDEN = '4031',
-  BLOCK_FORBIDDEN = '4032',
+  USER_FORBIDDEN = '4030',
+  SOCIAL_LOGIN_FORBIDDEN = '4031',
+  REPORT_FORBIDDEN = '4032',
+  BLOCK_FORBIDDEN = '4033',
 }
 
 export enum UserExceptionEnum {


### PR DESCRIPTION
## #️⃣연관된 이슈
#117 
> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- role decorator, roles guard를 추가했습니다.
- items, reports, blocks에 관리자 가드 적용했습니다.
- Roles guard를 사용할 때는 UseGuards 아래에 Roles 데코레이터를 함께 추가해주세요!
- RolesGuard는 반드시 JwtAuthenticationGuard 다음으로 적어주시고, Roles 데코레이터에는 접근권한이 필요한 역할을 함께 적어주시면 됩니다.
```ts
  @Delete(':id')
  @UseGuards(JwtAuthenticationGuard, RolesGuard)
  @Roles(AuthorityName.ADMIN)
  @ApiOperation({ summary: '유저 차단 삭제 (관리자)' })
  @ApiResponse({
    status: 200,
    description: '차단이 삭제되었습니다.',
  })
  async remove(@Param('id') id: string) {
    await this.blocksService.remove(+id);
    return HttpResponse.success('차단이 삭제되었습니다.');
  }
```

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
