### PR TITLE
회원가입 시 탈퇴회원과 관련한 버그, 탈퇴회원 재가입 시 처리

### DIFF
--- a/src/@types/enum/user.enum.ts
+++ b/src/@types/enum/user.enum.ts
@@ -13,6 +13,7 @@ export enum AuthorityName {
 export enum State {
   JOINED = '가입',
   WITHDRAWN = '탈퇴',
+  EXPELLED = '추방',
 }
 
 export enum Gender {

--- a/src/domain/authentication/authentication.controller.ts
+++ b/src/domain/authentication/authentication.controller.ts
@@ -18,6 +18,7 @@ import { JwtAuthenticationGuard } from './guards/jwt-authentication.guard';
 import { RefreshAuthenticationGuard } from './guards/refresh-authentication.guard';
 import { LoginDto } from '@/domain/authentication/dto/login.dto';
 import { HttpResponse } from '@/@types/http-response';
+import { AuthenticationProvider } from '@/@types/enum/user.enum';
 
 @Controller('authentication')
 @ApiTags('authentication')
@@ -154,7 +155,7 @@ export class AuthenticationController {
   ) {
     const { user, accessCookie, refreshCookie, message, userData } =
       await this.authenticationService.socialLogin(
-        'kakao',
+        AuthenticationProvider.KAKAO,
         authorizationCode,
         null,
       );
@@ -233,7 +234,7 @@ export class AuthenticationController {
   ) {
     const { user, accessCookie, refreshCookie, message, userData } =
       await this.authenticationService.socialLogin(
-        'naver',
+        AuthenticationProvider.NAVER,
         authorizationCode,
         state,
       );
@@ -308,7 +309,7 @@ export class AuthenticationController {
   ) {
     const { user, accessCookie, refreshCookie, message, userData } =
       await this.authenticationService.socialLogin(
-        'google',
+        AuthenticationProvider.GOOGLE,
         authorizationCode,
         null,
       );

--- a/src/domain/authentication/authentication.controller.ts
+++ b/src/domain/authentication/authentication.controller.ts
@@ -75,6 +75,10 @@ export class AuthenticationController {
     status: 404,
     description: '사용자를 찾을 수 없습니다.',
   })
+  @ApiResponse({
+    status: 403,
+    description: '이미 탈퇴한 회원입니다, 추방된 회원입니다.',
+  })
   async emailLogin(@Body() loginDto: LoginDto, @Res() response: Response) {
     const user = await this.authenticationService.emailLogin(loginDto);
     const accessCookie =

--- a/src/domain/authentication/authentication.service.ts
+++ b/src/domain/authentication/authentication.service.ts
@@ -22,7 +22,7 @@ import {
   UserNotFoundException,
 } from '@/domain/users/exceptions/users.exception';
 import { LoginDto } from '@/domain/authentication/dto/login.dto';
-import { State } from '@/@types/enum/user.enum';
+import { AuthenticationProvider, State } from '@/@types/enum/user.enum';
 
 @Injectable()
 export class AuthenticationService {
@@ -44,20 +44,41 @@ export class AuthenticationService {
     if (authenticationProvider === 'email' && (!email || !password)) {
       throw new UserBadRequestException('이메일 및 비밀번호가 필요합니다.');
     }
+
     if (socialId) {
-      const existingSocialId = await this.usersService.findBySocialId(socialId);
-      if (existingSocialId) {
-        throw new UserBadRequestException('존재하는 소셜id 입니다.');
+      const existingUser = await this.usersService.findBySocialId(socialId);
+      if (existingUser) {
+        if (existingUser.state === State.WITHDRAWN) {
+          await this.usersService.update(existingUser.id, registrationData);
+          return;
+        } else if (existingUser.state === State.EXPELLED) {
+          throw new UserExpelledException('추방된 회원입니다.');
+        } else {
+          throw new UserBadRequestException('존재하는 소셜id 입니다.');
+        }
       }
     }
+
     if (email) {
-      const existingEmail = await this.usersService.findByEmail(email);
-      if (existingEmail) {
-        throw new UserBadRequestException('존재하는 이메일입니다.');
+      const existingUser = await this.usersService.findByEmail(email);
+      if (existingUser) {
+        if (existingUser.state === State.WITHDRAWN) {
+          await this.usersService.update(existingUser.id, registrationData);
+          return;
+        } else if (existingUser.state === State.EXPELLED) {
+          throw new UserExpelledException('추방된 회원입니다.');
+        } else {
+          throw new UserBadRequestException('존재하는 이메일입니다.');
+        }
       }
     }
-    const result = await this.usersService.checkNickname(nickname);
-    if (result === false) {
+
+    const result = await this.usersService.checkNickname(
+      nickname,
+      registrationData.email,
+      registrationData.socialId,
+    );
+    if (!result) {
       throw new UserBadRequestException('존재하는 닉네임입니다.');
     }
 
@@ -98,7 +119,7 @@ export class AuthenticationService {
 
   // 소셜 로그인
   async socialLogin(
-    provider: string,
+    provider: AuthenticationProvider,
     authorizationCode: string,
     state: string,
   ) {
@@ -106,14 +127,14 @@ export class AuthenticationService {
     let userData;
 
     switch (provider) {
-      case 'kakao':
+      case AuthenticationProvider.KAKAO:
         accessToken = await this.getKakaoToken(
           authorizationCode,
           process.env.KAKAO_REST_API_KEY,
         );
         userData = await this.getKakaoUserData(accessToken);
         break;
-      case 'naver':
+      case AuthenticationProvider.NAVER:
         accessToken = await this.getNaverToken(
           authorizationCode,
           state,
@@ -122,7 +143,7 @@ export class AuthenticationService {
         );
         userData = await this.getNaverUserData(accessToken);
         break;
-      case 'google':
+      case AuthenticationProvider.GOOGLE:
         accessToken = await this.getGoogleToken(
           authorizationCode,
           process.env.GOOGLE_CLIENT_ID,

--- a/src/domain/authentication/exceptions/authentication.exception.ts
+++ b/src/domain/authentication/exceptions/authentication.exception.ts
@@ -54,3 +54,15 @@ export class NotAdultException extends BaseException {
     super(AuthExceptionEnum.NOT_ADULT, HttpStatus.FORBIDDEN, message);
   }
 }
+
+export class UserWithdrawnException extends BaseException {
+  constructor(message: string) {
+    super(AuthExceptionEnum.USER_WITHDRAWN, HttpStatus.FORBIDDEN, message);
+  }
+}
+
+export class UserExpelledException extends BaseException {
+  constructor(message: string) {
+    super(AuthExceptionEnum.USER_EXPELLED, HttpStatus.FORBIDDEN, message);
+  }
+}

--- a/src/domain/users/dto/update-user.dto.ts
+++ b/src/domain/users/dto/update-user.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateUserDto } from './create-user.dto';
+
+export class UpdateUserDto extends PartialType(CreateUserDto) {}

--- a/src/domain/users/users.controller.ts
+++ b/src/domain/users/users.controller.ts
@@ -10,6 +10,7 @@ import {
   Req,
   Param,
   Query,
+  Headers,
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
@@ -188,8 +189,16 @@ export class UsersController {
       },
     },
   })
-  async checkNickname(@Param('nickname') nickname: string) {
-    const result = await this.usersService.checkNickname(nickname);
+  async checkNickname(
+    @Param('nickname') nickname: string,
+    @Headers('email') email?: string,
+    @Headers('socialId') socialId?: string,
+  ) {
+    const result = await this.usersService.checkNickname(
+      nickname,
+      email,
+      socialId,
+    );
     return HttpResponse.success('닉네임 사용 가능 여부', {
       available: result,
     });

--- a/src/domain/users/users.controller.ts
+++ b/src/domain/users/users.controller.ts
@@ -19,6 +19,9 @@ import { JwtAuthenticationGuard } from '../authentication/guards/jwt-authenticat
 import { HttpResponse } from '@/@types/http-response';
 import { Animal } from '@/@types/enum/animal.enum';
 import { OtherUserProfileDto } from './dto/other-user-profile.dto';
+import { RolesGuard } from '../authentication/guards/roles.guard';
+import { Roles } from '../authentication/decorators/role.decorator';
+import { AuthorityName } from '@/@types/enum/user.enum';
 
 @Controller('users')
 @ApiTags('users')
@@ -386,6 +389,63 @@ export class UsersController {
     const { user } = request;
     await this.usersService.remove(user.id, exitReasonDto);
     return HttpResponse.success('회원 탈퇴가 완료되었습니다.');
+  }
+
+  /* 관리자 페이지 */
+  @Get('/admin')
+  @UseGuards(JwtAuthenticationGuard, RolesGuard)
+  @Roles(AuthorityName.ADMIN)
+  @ApiOperation({ summary: '전체 회원 조회(관리자)' })
+  @ApiResponse({
+    status: 200,
+    description: '전체 회원이 조회되었습니다.',
+    schema: {
+      type: 'object',
+      properties: {
+        code: { type: 'number', example: 200 },
+        message: {
+          type: 'string',
+          example: '전체 회원이 조회되었습니다.',
+        },
+        data: {
+          type: 'array',
+          items: {
+            type: 'object',
+          },
+        },
+      },
+    },
+  })
+  async findAll() {
+    const users = await this.usersService.findAll();
+    users.forEach((user) => {
+      user.credential.password = undefined;
+      user.currentRefreshToken = undefined;
+    });
+    return HttpResponse.success('전체 회원이 조회되었습니다.', users);
+  }
+
+  @Delete('/admin/:userId')
+  @UseGuards(JwtAuthenticationGuard, RolesGuard)
+  @Roles(AuthorityName.ADMIN)
+  @ApiOperation({ summary: '회원 추방(관리자)' })
+  @ApiResponse({
+    status: 200,
+    description: '회원 추방이 완료되었습니다.',
+    schema: {
+      type: 'object',
+      properties: {
+        code: { type: 'number', example: 200 },
+        message: {
+          type: 'string',
+          example: '회원 추방이 완료되었습니다.',
+        },
+      },
+    },
+  })
+  async expelMember(@Param('userId') userId: string) {
+    await this.usersService.expelMember(userId);
+    return HttpResponse.success('회원 추방이 완료되었습니다.');
   }
 
   // 임시

--- a/src/domain/users/users.service.ts
+++ b/src/domain/users/users.service.ts
@@ -287,11 +287,7 @@ export class UsersService {
 
   // 닉네임 수정
   async updateNickname(user: User, nickname: string): Promise<void> {
-    const existingUser = await this.checkNickname(
-      nickname,
-      user.credential.email,
-      user.socialId,
-    );
+    const existingUser = await this.checkNickname(nickname);
     if (!existingUser) {
       throw new UserBadRequestException('중복된 닉네임입니다.');
     }

--- a/src/lib/exceptions/exception.enum.ts
+++ b/src/lib/exceptions/exception.enum.ts
@@ -58,6 +58,8 @@ export enum AuthExceptionEnum {
   REPORT_FORBIDDEN = '4032',
   BLOCK_FORBIDDEN = '4033',
   NOT_ADULT = '4034',
+  USER_WITHDRAWN = '4035',
+  USER_EXPELLED = '4036',
 }
 
 export enum UserExceptionEnum {


### PR DESCRIPTION
## #️⃣연관된 이슈
#122 
> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- user.state enum에 '가입', '탈퇴' 외에 '추방' 추가
- (관리자) 전체 회원 조회 api, 회원 추방 api 구현
- 탈퇴한 회원, 추방된 회원이 로그인 시 에러처리
- 닉네임 중복 확인 api에 email, socialId 옵셔널로 함께 전달, 탈퇴한 회원의 경우만 같은 닉네임 사용 가능하도록 함
- 회원가입 시 가입경로에 따라 email, socialId로 존재하는 회원 여부 검사, state에 따라 처리('가입' -> 에러, '추방' -> 가입 제한, '탈퇴' -> 재가입 가능, 회원정보 업데이트)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
- 탈퇴했던 회원이 재가입을 했을 때 업데이트한 정보 외에 포인트나 스티커 등 기존의 데이터도 초기화하는게 좋을까요? 일단은 본인인증 여부만 false로 설정해놓은 상태입니다!
